### PR TITLE
feat(kafka): add Kafka producer/consumer and config management

### DIFF
--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -1,0 +1,127 @@
+# Config Package
+
+This package provides centralized configuration management for the application using [Viper](https://github.com/spf13/viper).
+
+## Features
+
+- Reads configuration from `.env` file
+- Automatic environment variable binding
+- Comprehensive validation of all required fields
+- Type-safe configuration struct
+- Helper methods for common connection strings
+
+## Usage
+
+### Basic Usage
+
+```go
+package main
+
+import (
+    "log"
+    "github.com/mateusmlo/altimit-ecomm/internal/config"
+)
+
+func main() {
+    // Load configuration
+    cfg, err := config.Load()
+    if err != nil {
+        log.Fatalf("Failed to load config: %v", err)
+    }
+
+    // Access configuration values
+    log.Printf("Kafka brokers: %v", cfg.Kafka.Brokers)
+    log.Printf("Region: %s", cfg.Region)
+}
+```
+
+### Accessing Configuration Values
+
+```go
+// Kafka configuration
+brokers := cfg.Kafka.Brokers
+
+// PostgreSQL configuration
+dbUser := cfg.Postgres.User
+dbPass := cfg.Postgres.Password
+dbHost := cfg.Postgres.Host
+dbPort := cfg.Postgres.Port
+dbName := cfg.Postgres.DB
+
+// Redis configuration
+redisHost := cfg.Redis.Host
+redisPort := cfg.Redis.Port
+
+// Topics
+ordersTopicName := cfg.Topics.Commands.Orders
+inventoryCommandsTopic := cfg.Topics.Commands.Inventory
+inventoryRepliesTopic := cfg.Topics.Replies.Inventory
+
+// Consumer groups
+orchestratorGroup := cfg.ConsumerGroups.SagaOrchestrator
+
+// Region
+region := cfg.Region
+```
+
+### Helper Methods
+
+The config package provides convenient helper methods:
+
+```go
+// Get PostgreSQL connection string
+connStr := cfg.GetPostgresConnectionString()
+// Returns: "host=localhost port=5432 user=user password=pass dbname=db sslmode=disable"
+
+// Get Redis address
+redisAddr := cfg.GetRedisAddress()
+// Returns: "localhost:6379"
+```
+
+## Configuration Structure
+
+The configuration is organized into the following sections:
+
+### Kafka Configuration
+- `Brokers`: List of Kafka broker addresses
+
+### PostgreSQL Configuration
+- `User`: Database user
+- `Password`: Database password
+- `DB`: Database name
+- `Host`: Database host
+- `Port`: Database port
+
+### Redis Configuration
+- `Host`: Redis host
+- `Port`: Redis port
+
+### Topics Configuration
+- `Commands`: Command topic names (Orders, Inventory, Payment, Notification)
+- `Replies`: Reply topic names (Inventory, Payment, Notification)
+- `DLQ`: Dead letter queue topic names
+
+### Consumer Groups
+- `SagaOrchestrator`: Saga orchestrator consumer group
+- `InventoryService`: Inventory service consumer group
+- `PaymentService`: Payment service consumer group
+- `NotificationService`: Notification service consumer group
+
+### Other
+- `Region`: Application region
+
+## Validation
+
+All required fields are validated when the configuration is loaded. If any required field is missing or invalid, `Load()` will return an error. This ensures the application fails fast with a clear error message rather than encountering issues at runtime.
+
+## Environment Variables
+
+See `.env.example` for a complete list of required environment variables.
+
+## Testing
+
+Run the tests:
+
+```bash
+go test ./internal/config
+```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,269 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// Config holds all configuration for the application
+type Config struct {
+	Kafka          KafkaConfig
+	Postgres       PostgresConfig
+	Redis          RedisConfig
+	Topics         TopicsConfig
+	ConsumerGroups ConsumerGroupsConfig
+	Region         string
+}
+
+// KafkaConfig holds Kafka-related configuration
+type KafkaConfig struct {
+	Brokers           []string
+	MaxRequestRetries int
+	MaxRecordRetries  int
+}
+
+// PostgresConfig holds PostgreSQL-related configuration
+type PostgresConfig struct {
+	User     string
+	Password string
+	DB       string
+	Host     string
+	Port     int
+}
+
+// RedisConfig holds Redis-related configuration
+type RedisConfig struct {
+	Host string
+	Port int
+}
+
+// TopicsConfig holds all Kafka topic names
+type TopicsConfig struct {
+	Commands CommandTopics
+	Replies  ReplyTopics
+	DLQ      DLQTopics
+}
+
+// CommandTopics holds command topic names
+type CommandTopics struct {
+	Orders       string
+	Inventory    string
+	Payment      string
+	Notification string
+}
+
+// ReplyTopics holds reply topic names
+type ReplyTopics struct {
+	Inventory    string
+	Payment      string
+	Notification string
+}
+
+// DLQTopics holds dead letter queue topic names
+type DLQTopics struct {
+	Orders string
+}
+
+// ConsumerGroupsConfig holds all consumer group IDs
+type ConsumerGroupsConfig struct {
+	SagaOrchestrator    string
+	InventoryService    string
+	PaymentService      string
+	NotificationService string
+}
+
+// Load reads configuration from environment variables using Viper
+func Load() (*Config, error) {
+	v := viper.New()
+
+	// Set the file name of the configurations file
+	v.SetConfigFile(".env")
+
+	// Enable automatic env variable reading
+	v.AutomaticEnv()
+
+	// Try to read the config file, but don't fail if it doesn't exist
+	// Environment variables will still be read
+	if err := v.ReadInConfig(); err != nil {
+		// Check if it's a file not found error
+		var configFileNotFoundError viper.ConfigFileNotFoundError
+		if !errors.As(err, &configFileNotFoundError) && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to read config file: %w", err)
+		}
+		// If file not found, we'll just use environment variables
+	}
+
+	// Build the config struct
+	cfg := &Config{
+		Kafka: KafkaConfig{
+			Brokers:           parseBrokers(v.GetString("KAFKA_BROKERS")),
+			MaxRequestRetries: v.GetInt("MAX_REQ_RETRIES"),
+			MaxRecordRetries:  v.GetInt("MAX_RECORD_RETRIES"),
+		},
+		Postgres: PostgresConfig{
+			User:     v.GetString("POSTGRES_USER"),
+			Password: v.GetString("POSTGRES_PASSWORD"),
+			DB:       v.GetString("POSTGRES_DB"),
+			Host:     v.GetString("POSTGRES_HOST"),
+			Port:     v.GetInt("POSTGRES_PORT"),
+		},
+		Redis: RedisConfig{
+			Host: v.GetString("REDIS_HOST"),
+			Port: v.GetInt("REDIS_PORT"),
+		},
+		Topics: TopicsConfig{
+			Commands: CommandTopics{
+				Orders:       v.GetString("ORDERS_TOPIC"),
+				Inventory:    v.GetString("INVENTORY_COMMANDS_TOPIC"),
+				Payment:      v.GetString("PAYMENT_COMMANDS_TOPIC"),
+				Notification: v.GetString("NOTIFICATION_COMMANDS_TOPIC"),
+			},
+			Replies: ReplyTopics{
+				Inventory:    v.GetString("INVENTORY_REPLIES_TOPIC"),
+				Payment:      v.GetString("PAYMENT_REPLIES_TOPIC"),
+				Notification: v.GetString("NOTIFICATION_REPLIES_TOPIC"),
+			},
+			DLQ: DLQTopics{
+				Orders: v.GetString("ORDERS_DLQ_TOPIC"),
+			},
+		},
+		ConsumerGroups: ConsumerGroupsConfig{
+			SagaOrchestrator:    v.GetString("SAGA_ORCHESTRATOR_GROUP"),
+			InventoryService:    v.GetString("INVENTORY_SERVICE_GROUP"),
+			PaymentService:      v.GetString("PAYMENT_SERVICE_GROUP"),
+			NotificationService: v.GetString("NOTIFICATION_SERVICE_GROUP"),
+		},
+		Region: v.GetString("REGION"),
+	}
+
+	// Validate the configuration
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("config validation failed: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// Validate checks that all required configuration values are present and valid
+func (c *Config) Validate() error {
+	// Validate Kafka config
+	if len(c.Kafka.Brokers) == 0 {
+		return fmt.Errorf("KAFKA_BROKERS is required")
+	}
+
+	// Validate Postgres config
+	if c.Postgres.User == "" {
+		return fmt.Errorf("POSTGRES_USER is required")
+	}
+	if c.Postgres.Password == "" {
+		return fmt.Errorf("POSTGRES_PASSWORD is required")
+	}
+	if c.Postgres.DB == "" {
+		return fmt.Errorf("POSTGRES_DB is required")
+	}
+	if c.Postgres.Host == "" {
+		return fmt.Errorf("POSTGRES_HOST is required")
+	}
+	if c.Postgres.Port == 0 {
+		return fmt.Errorf("POSTGRES_PORT is required")
+	}
+
+	// Validate Redis config
+	if c.Redis.Host == "" {
+		return fmt.Errorf("REDIS_HOST is required")
+	}
+	if c.Redis.Port == 0 {
+		return fmt.Errorf("REDIS_PORT is required")
+	}
+
+	// Validate command topics
+	if c.Topics.Commands.Orders == "" {
+		return fmt.Errorf("ORDERS_TOPIC is required")
+	}
+	if c.Topics.Commands.Inventory == "" {
+		return fmt.Errorf("INVENTORY_COMMANDS_TOPIC is required")
+	}
+	if c.Topics.Commands.Payment == "" {
+		return fmt.Errorf("PAYMENT_COMMANDS_TOPIC is required")
+	}
+	if c.Topics.Commands.Notification == "" {
+		return fmt.Errorf("NOTIFICATION_COMMANDS_TOPIC is required")
+	}
+
+	// Validate reply topics
+	if c.Topics.Replies.Inventory == "" {
+		return fmt.Errorf("INVENTORY_REPLIES_TOPIC is required")
+	}
+	if c.Topics.Replies.Payment == "" {
+		return fmt.Errorf("PAYMENT_REPLIES_TOPIC is required")
+	}
+	if c.Topics.Replies.Notification == "" {
+		return fmt.Errorf("NOTIFICATION_REPLIES_TOPIC is required")
+	}
+
+	// Validate DLQ topics
+	if c.Topics.DLQ.Orders == "" {
+		return fmt.Errorf("ORDERS_DLQ_TOPIC is required")
+	}
+
+	// Validate consumer groups
+	if c.ConsumerGroups.SagaOrchestrator == "" {
+		return fmt.Errorf("SAGA_ORCHESTRATOR_GROUP is required")
+	}
+	if c.ConsumerGroups.InventoryService == "" {
+		return fmt.Errorf("INVENTORY_SERVICE_GROUP is required")
+	}
+	if c.ConsumerGroups.PaymentService == "" {
+		return fmt.Errorf("PAYMENT_SERVICE_GROUP is required")
+	}
+	if c.ConsumerGroups.NotificationService == "" {
+		return fmt.Errorf("NOTIFICATION_SERVICE_GROUP is required")
+	}
+
+	// Validate region
+	if c.Region == "" {
+		return fmt.Errorf("REGION is required")
+	}
+
+	return nil
+}
+
+// parseBrokers splits comma-separated broker addresses
+func parseBrokers(brokers string) []string {
+	if brokers == "" {
+		return []string{}
+	}
+
+	parts := strings.Split(brokers, ",")
+	result := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+
+	return result
+}
+
+// GetPostgresConnectionString returns a formatted PostgreSQL connection string
+func (c *Config) GetPostgresConnectionString() string {
+	return fmt.Sprintf(
+		"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
+		c.Postgres.Host,
+		c.Postgres.Port,
+		c.Postgres.User,
+		c.Postgres.Password,
+		c.Postgres.DB,
+	)
+}
+
+// GetRedisAddress returns the Redis address in host:port format
+func (c *Config) GetRedisAddress() string {
+	return fmt.Sprintf("%s:%d", c.Redis.Host, c.Redis.Port)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,261 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	// Set up test environment variables
+	envVars := map[string]string{
+		"KAFKA_BROKERS":               "localhost:9092",
+		"KAFKA_MAX_REQ_RETRIES":       "5",
+		"KAFKA_MAX_RECORD_RETRIES":    "10",
+		"POSTGRES_USER":               "test_user",
+		"POSTGRES_PASSWORD":           "test_pass",
+		"POSTGRES_DB":                 "test_db",
+		"POSTGRES_HOST":               "localhost",
+		"POSTGRES_PORT":               "5432",
+		"REDIS_HOST":                  "localhost",
+		"REDIS_PORT":                  "6379",
+		"ORDERS_TOPIC":                "orders",
+		"INVENTORY_COMMANDS_TOPIC":    "inventory.commands",
+		"PAYMENT_COMMANDS_TOPIC":      "payment.commands",
+		"NOTIFICATION_COMMANDS_TOPIC": "notification.commands",
+		"INVENTORY_REPLIES_TOPIC":     "inventory.replies",
+		"PAYMENT_REPLIES_TOPIC":       "payment.replies",
+		"NOTIFICATION_REPLIES_TOPIC":  "notification.replies",
+		"ORDERS_DLQ_TOPIC":            "orders.dlq",
+		"SAGA_ORCHESTRATOR_GROUP":     "saga-orchestrator",
+		"INVENTORY_SERVICE_GROUP":     "inventory-service",
+		"PAYMENT_SERVICE_GROUP":       "payment-service",
+		"NOTIFICATION_SERVICE_GROUP":  "notification-service",
+		"REGION":                      "US",
+	}
+
+	for key, value := range envVars {
+		os.Setenv(key, value)
+	}
+	defer func() {
+		for key := range envVars {
+			os.Unsetenv(key)
+		}
+	}()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	// Validate Kafka config
+	if len(cfg.Kafka.Brokers) != 1 || cfg.Kafka.Brokers[0] != "localhost:9092" {
+		t.Errorf("Expected Kafka brokers [localhost:9092], got %v", cfg.Kafka.Brokers)
+	}
+	if cfg.Kafka.MaxRequestRetries != 5 {
+		t.Errorf("Expected Kafka max request retries 5, got %d", cfg.Kafka.MaxRequestRetries)
+	}
+	if cfg.Kafka.MaxRecordRetries != 10 {
+		t.Errorf("Expected Kafka max record retries 10, got %d", cfg.Kafka.MaxRecordRetries)
+	}
+
+	// Validate Postgres config
+	if cfg.Postgres.User != "test_user" {
+		t.Errorf("Expected Postgres user 'test_user', got '%s'", cfg.Postgres.User)
+	}
+	if cfg.Postgres.Password != "test_pass" {
+		t.Errorf("Expected Postgres password 'test_pass', got '%s'", cfg.Postgres.Password)
+	}
+	if cfg.Postgres.DB != "test_db" {
+		t.Errorf("Expected Postgres DB 'test_db', got '%s'", cfg.Postgres.DB)
+	}
+	if cfg.Postgres.Host != "localhost" {
+		t.Errorf("Expected Postgres host 'localhost', got '%s'", cfg.Postgres.Host)
+	}
+	if cfg.Postgres.Port != 5432 {
+		t.Errorf("Expected Postgres port 5432, got %d", cfg.Postgres.Port)
+	}
+
+	// Validate Redis config
+	if cfg.Redis.Host != "localhost" {
+		t.Errorf("Expected Redis host 'localhost', got '%s'", cfg.Redis.Host)
+	}
+	if cfg.Redis.Port != 6379 {
+		t.Errorf("Expected Redis port 6379, got %d", cfg.Redis.Port)
+	}
+
+	// Validate region
+	if cfg.Region != "US" {
+		t.Errorf("Expected region 'US', got '%s'", cfg.Region)
+	}
+}
+
+func TestParseBrokers(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "single broker",
+			input:    "localhost:9092",
+			expected: []string{"localhost:9092"},
+		},
+		{
+			name:     "multiple brokers",
+			input:    "localhost:9092,localhost:9093,localhost:9094",
+			expected: []string{"localhost:9092", "localhost:9093", "localhost:9094"},
+		},
+		{
+			name:     "brokers with spaces",
+			input:    "localhost:9092, localhost:9093, localhost:9094",
+			expected: []string{"localhost:9092", "localhost:9093", "localhost:9094"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseBrokers(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Fatalf("Expected %d brokers, got %d", len(tt.expected), len(result))
+			}
+			for i, broker := range result {
+				if broker != tt.expected[i] {
+					t.Errorf("Expected broker '%s', got '%s'", tt.expected[i], broker)
+				}
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *Config
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid config",
+			config: &Config{
+				Kafka: KafkaConfig{
+					Brokers: []string{"localhost:9092"},
+				},
+				Postgres: PostgresConfig{
+					User:     "user",
+					Password: "pass",
+					DB:       "db",
+					Host:     "localhost",
+					Port:     5432,
+				},
+				Redis: RedisConfig{
+					Host: "localhost",
+					Port: 6379,
+				},
+				Topics: TopicsConfig{
+					Commands: CommandTopics{
+						Orders:       "orders",
+						Inventory:    "inventory.commands",
+						Payment:      "payment.commands",
+						Notification: "notification.commands",
+					},
+					Replies: ReplyTopics{
+						Inventory:    "inventory.replies",
+						Payment:      "payment.replies",
+						Notification: "notification.replies",
+					},
+					DLQ: DLQTopics{
+						Orders: "orders.dlq",
+					},
+				},
+				ConsumerGroups: ConsumerGroupsConfig{
+					SagaOrchestrator:    "saga-orchestrator",
+					InventoryService:    "inventory-service",
+					PaymentService:      "payment-service",
+					NotificationService: "notification-service",
+				},
+				Region: "US",
+			},
+			expectError: false,
+		},
+		{
+			name: "missing kafka brokers",
+			config: &Config{
+				Kafka: KafkaConfig{
+					Brokers: []string{},
+				},
+			},
+			expectError: true,
+			errorMsg:    "KAFKA_BROKERS is required",
+		},
+		{
+			name: "missing postgres user",
+			config: &Config{
+				Kafka: KafkaConfig{
+					Brokers: []string{"localhost:9092"},
+				},
+				Postgres: PostgresConfig{
+					User: "",
+				},
+			},
+			expectError: true,
+			errorMsg:    "POSTGRES_USER is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				} else if tt.errorMsg != "" && err.Error() != tt.errorMsg {
+					t.Errorf("Expected error '%s', got '%s'", tt.errorMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error, got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestGetPostgresConnectionString(t *testing.T) {
+	cfg := &Config{
+		Postgres: PostgresConfig{
+			User:     "test_user",
+			Password: "test_pass",
+			DB:       "test_db",
+			Host:     "localhost",
+			Port:     5432,
+		},
+	}
+
+	expected := "host=localhost port=5432 user=test_user password=test_pass dbname=test_db sslmode=disable"
+	result := cfg.GetPostgresConnectionString()
+
+	if result != expected {
+		t.Errorf("Expected connection string '%s', got '%s'", expected, result)
+	}
+}
+
+func TestGetRedisAddress(t *testing.T) {
+	cfg := &Config{
+		Redis: RedisConfig{
+			Host: "localhost",
+			Port: 6379,
+		},
+	}
+
+	expected := "localhost:6379"
+	result := cfg.GetRedisAddress()
+
+	if result != expected {
+		t.Errorf("Expected Redis address '%s', got '%s'", expected, result)
+	}
+}

--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -1,0 +1,90 @@
+package kafka
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/mateusmlo/altimit-ecomm/internal/config"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// I  know two clients is not ideal but the separation of concerns is just while I get used to all this stuff
+
+type Consumer struct {
+	Client *kgo.Client
+	cfg    *config.Config
+}
+
+type RecordHandler func(ctx context.Context, record *kgo.Record) error
+
+func NewConsumer(cfg *config.Config, groupID string, topics []string) (*Consumer, error) {
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(cfg.Kafka.Brokers...),
+		kgo.WithLogger(kgo.BasicLogger(log.Writer(), kgo.LogLevelDebug, nil)),
+		kgo.ConsumerGroup(groupID),
+		kgo.ConsumeTopics(topics...),
+		kgo.DisableAutoCommit(),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &Consumer{
+		Client: client,
+		cfg:    cfg,
+	}, nil
+}
+
+func (c *Consumer) Consume(ctx context.Context, handler RecordHandler) error {
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("Shutdown consumer...")
+
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+			defer cancel()
+
+			if err := c.Client.CommitUncommittedOffsets(shutdownCtx); err != nil {
+				log.Printf("Failed to commit offsets during shutdown: %v", err)
+			}
+
+			return ctx.Err()
+		default:
+			var processErr error
+
+			fetches := c.Client.PollFetches(ctx)
+
+			if fetches.IsClientClosed() {
+				return errors.New("client closed")
+			}
+
+			if err := fetches.Err(); err != nil {
+				log.Printf("fetch records error: %v", err)
+				return err
+			}
+
+			fetches.EachRecord(func(record *kgo.Record) {
+				if processErr != nil {
+					return
+				}
+
+				if err := handler(ctx, record); err != nil {
+					log.Printf("error handling record: %v", err)
+					processErr = err
+					return
+				}
+			})
+
+			if processErr != nil {
+				//TODO: add to DLQ
+				return processErr
+			}
+
+			c.Client.CommitUncommittedOffsets(ctx)
+		}
+	}
+}

--- a/internal/kafka/producer.go
+++ b/internal/kafka/producer.go
@@ -1,0 +1,88 @@
+package kafka
+
+import (
+	"context"
+	"log"
+
+	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
+	"github.com/mateusmlo/altimit-ecomm/internal/config"
+	"github.com/mateusmlo/altimit-ecomm/internal/models"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+type Producer struct {
+	Client *kgo.Client
+	cfg    *config.Config
+}
+
+type RecordMetadata struct {
+	eventType models.EventType
+	eventID   uuid.UUID
+	sagaID    uuid.UUID
+	orderID   uuid.UUID
+	timestamp int64
+}
+
+func (rm *RecordMetadata) MarshalBinary() ([]byte, error) {
+	return sonic.Marshal(rm)
+}
+
+func NewProducer(cfg *config.Config) (*Producer, error) {
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(cfg.Kafka.Brokers...),
+		kgo.WithLogger(kgo.BasicLogger(log.Writer(), kgo.LogLevelDebug, nil)),
+		kgo.ClientID("altimit"),
+		kgo.RequiredAcks(kgo.AllISRAcks()),
+		kgo.RecordRetries(cfg.Kafka.MaxRecordRetries),
+		kgo.RequestRetries(cfg.Kafka.MaxRequestRetries),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &Producer{Client: client, cfg: cfg}, nil
+}
+
+func (p *Producer) PublishEvent(ctx context.Context, topic string, key []byte, ev models.Event) error {
+	msgPayload, err := ev.Payload.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	rm := RecordMetadata{
+		eventType: ev.Event,
+		eventID:   ev.EventID,
+		sagaID:    ev.SagaID,
+		orderID:   ev.OrderID,
+		timestamp: ev.Timestamp,
+	}
+
+	rmBytes, err := rm.MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	msg := &kgo.Record{
+		Topic: topic,
+		Key:   key,
+		Value: msgPayload,
+		Headers: []kgo.RecordHeader{
+			{
+				Key:   "metadata",
+				Value: rmBytes,
+			},
+		},
+	}
+
+	if err := p.Client.ProduceSync(ctx, msg).FirstErr(); err != nil {
+		log.Printf("Failed to publish event %s after retries: %v", ev.EventID, err)
+		//TODO: emit metrics
+		return err
+	}
+
+	log.Printf("Published event %v to topic %s", ev.EventID, topic)
+
+	return nil
+}


### PR DESCRIPTION
Add Kafka infrastructure with franz-go client library for event-driven communication:
- Config management with Viper for environment-based configuration
- Producer for publishing events to Kafka topics with metadata headers
- Consumer with manual offset management and graceful shutdown
- Topic and consumer group configuration for saga orchestration