### PR TITLE
feat: wire idempotency enforcement into inventory and payment handlers

### DIFF
--- a/cmd/inventory/integration_test.go
+++ b/cmd/inventory/integration_test.go
@@ -321,8 +321,9 @@ func startService(ctx context.Context, t *testing.T, cfg *config.Config, db *gor
 	require.NoError(t, err)
 
 	repo := repository.NewInventoryReservationRepository(db)
+	idempotencyRepo := repository.NewIdempotencyRepository(db)
 	service := inventory.NewInventoryService(repo)
-	handler := inventory.NewHandler(service, producer, cfg)
+	handler := inventory.NewHandler(service, producer, idempotencyRepo, cfg)
 
 	// Use a unique group ID per test to avoid offset conflicts
 	groupID := "inventory-svc-test-" + uuid.NewString()[:8]

--- a/cmd/inventory/main.go
+++ b/cmd/inventory/main.go
@@ -32,9 +32,10 @@ func main() {
 	}
 
 	repo := repository.NewInventoryReservationRepository(db)
+	idempotencyRepo := repository.NewIdempotencyRepository(db)
 	service := inventory.NewInventoryService(repo)
 
-	handler := inventory.NewHandler(service, producer, cfg)
+	handler := inventory.NewHandler(service, producer, idempotencyRepo, cfg)
 
 	consumer, err := kafka.NewConsumer(cfg, cfg.ConsumerGroups.InventoryService, []string{cfg.Topics.Commands.Inventory}, cfg.Topics.DLQ.Orders, producer.Client)
 	if err != nil {

--- a/cmd/orchestrator/integration_test.go
+++ b/cmd/orchestrator/integration_test.go
@@ -344,9 +344,10 @@ func startPaymentService(ctx context.Context, t *testing.T, cfg *config.Config, 
 
 	orderRepo := repository.NewOrderRepository(db)
 	paymentRepo := repository.NewPaymentRepository(db)
+	idempotencyRepo := repository.NewIdempotencyRepository(db)
 
 	service := payment.NewPaymentService(fake, paymentRepo)
-	handler := payment.NewHandler(service, producer, orderRepo, cfg)
+	handler := payment.NewHandler(service, producer, orderRepo, idempotencyRepo, cfg)
 
 	groupID := "payment-svc-test-" + uuid.NewString()[:8]
 	client, err := kgo.NewClient(

--- a/cmd/payment/integration_test.go
+++ b/cmd/payment/integration_test.go
@@ -248,9 +248,10 @@ func startService(ctx context.Context, t *testing.T, cfg *config.Config, db *gor
 
 	orderRepo := repository.NewOrderRepository(db)
 	paymentRepo := repository.NewPaymentRepository(db)
+	idempotencyRepo := repository.NewIdempotencyRepository(db)
 
 	service := payment.NewPaymentService(fake, paymentRepo)
-	handler := payment.NewHandler(service, producer, orderRepo, cfg)
+	handler := payment.NewHandler(service, producer, orderRepo, idempotencyRepo, cfg)
 
 	// AtEnd + unique group so each test only sees records published after it
 	// starts. Prior tests leave messages on the topic, and the handler errors

--- a/cmd/payment/main.go
+++ b/cmd/payment/main.go
@@ -35,10 +35,11 @@ func main() {
 	stripeClient := stripe.NewStripeClient(cfg.Stripe)
 	orderRepo := repository.NewOrderRepository(db)
 	paymentRepo := repository.NewPaymentRepository(db)
+	idempotencyRepo := repository.NewIdempotencyRepository(db)
 	stripeService := stripe.NewStripeService(stripeClient)
 
 	service := payment.NewPaymentService(stripeService, paymentRepo)
-	handler := payment.NewHandler(service, producer, orderRepo, cfg)
+	handler := payment.NewHandler(service, producer, orderRepo, idempotencyRepo, cfg)
 
 	consumer, err := kafka.NewConsumer(cfg, cfg.ConsumerGroups.PaymentService, []string{cfg.Topics.Commands.Payment}, cfg.Topics.DLQ.Orders, producer.Client)
 	if err != nil {

--- a/internal/inventory/handler.go
+++ b/internal/inventory/handler.go
@@ -3,6 +3,7 @@ package inventory
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/bytedance/sonic"
 	"github.com/google/uuid"
@@ -10,20 +11,23 @@ import (
 	"github.com/mateusmlo/altimit-ecomm/internal/errs"
 	"github.com/mateusmlo/altimit-ecomm/internal/kafka"
 	"github.com/mateusmlo/altimit-ecomm/internal/models"
+	"github.com/mateusmlo/altimit-ecomm/internal/repository"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 type Handler struct {
-	service  *InventoryService
-	producer *kafka.Producer
-	config   *config.Config
+	service         *InventoryService
+	producer        kafka.EventPublisher
+	idempotencyRepo repository.IdempotencyRepository
+	config          *config.Config
 }
 
-func NewHandler(service *InventoryService, producer *kafka.Producer, config *config.Config) *Handler {
+func NewHandler(service *InventoryService, producer kafka.EventPublisher, idempotencyRepo repository.IdempotencyRepository, config *config.Config) *Handler {
 	return &Handler{
-		service:  service,
-		producer: producer,
-		config:   config,
+		service:         service,
+		producer:        producer,
+		idempotencyRepo: idempotencyRepo,
+		config:          config,
 	}
 }
 
@@ -31,6 +35,17 @@ func (h *Handler) HandleCommand(ctx context.Context, rec *kgo.Record) error {
 	metadata, err := kafka.ExtractMetadata(rec.Headers)
 	if err != nil {
 		return err
+	}
+
+	key := metadata.EventID.String()
+
+	exists, err := h.idempotencyRepo.Exists(ctx, key)
+	if err != nil {
+		return err
+	}
+	if exists {
+		log.Printf("Duplicate command %s already processed, skipping", key)
+		return nil
 	}
 
 	var reply *models.InventoryReply
@@ -50,7 +65,25 @@ func (h *Handler) HandleCommand(ctx context.Context, rec *kgo.Record) error {
 		return err
 	}
 
-	return h.publishReply(ctx, metadata, reply)
+	if err := h.publishReply(ctx, metadata, reply); err != nil {
+		return err
+	}
+
+	return h.storeIdempotencyKey(ctx, key, reply)
+}
+
+// storeIdempotencyKey records the processed command keyed by EventID so a
+// redelivered command is suppressed. Called after a successful publishReply.
+func (h *Handler) storeIdempotencyKey(ctx context.Context, key string, reply *models.InventoryReply) error {
+	response, err := sonic.Marshal(reply)
+	if err != nil {
+		return err
+	}
+
+	return h.idempotencyRepo.Create(ctx, &models.IdempotencyKey{
+		Key:      key,
+		Response: response,
+	})
 }
 
 func (h *Handler) handleReserveInventory(ctx context.Context, orderID uuid.UUID, payload []byte) (*models.InventoryReply, error) {

--- a/internal/inventory/handler_test.go
+++ b/internal/inventory/handler_test.go
@@ -3,6 +3,7 @@ package inventory
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/google/uuid"
@@ -14,13 +15,41 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
+// mockIdempotencyRepo is a hand-written mock for IdempotencyRepository.
+type mockIdempotencyRepo struct {
+	existsResult bool
+	existsErr    error
+	createErr    error
+	createdKey   string
+	createCalled bool
+}
+
+func (m *mockIdempotencyRepo) Create(_ context.Context, key *models.IdempotencyKey) error {
+	m.createCalled = true
+	m.createdKey = key.Key
+	return m.createErr
+}
+
+func (m *mockIdempotencyRepo) GetByKey(_ context.Context, _ string) (*models.IdempotencyKey, error) {
+	return nil, nil
+}
+
+func (m *mockIdempotencyRepo) Exists(_ context.Context, _ string) (bool, error) {
+	return m.existsResult, m.existsErr
+}
+
+func (m *mockIdempotencyRepo) Delete(_ context.Context, _ string) error { return nil }
+
+func (m *mockIdempotencyRepo) DeleteOlderThan(_ context.Context, _ time.Duration) error { return nil }
+
 // newTestHandler builds a Handler with a nil producer.
 // Only safe for tests that never reach publishReply.
 func newTestHandler(svc *InventoryService) *Handler {
 	return &Handler{
-		service:  svc,
-		producer: nil,
-		config:   &config.Config{},
+		service:         svc,
+		producer:        nil,
+		idempotencyRepo: &mockIdempotencyRepo{},
+		config:          &config.Config{},
 	}
 }
 
@@ -105,4 +134,78 @@ func TestHandleCommand_ReleaseInventory_InvalidPayload(t *testing.T) {
 	})
 
 	assert.ErrorIs(t, err, errs.ErrMalformedPayload)
+}
+
+// mockPublisher records the last published event for assertions.
+type mockPublisher struct {
+	publishErr error
+	lastTopic  string
+	lastEvent  models.Event
+}
+
+func (m *mockPublisher) PublishEvent(_ context.Context, topic string, ev models.Event) error {
+	m.lastTopic = topic
+	m.lastEvent = ev
+	return m.publishErr
+}
+
+func TestHandleCommand_DuplicateSuppressed(t *testing.T) {
+	repo := &mockInventoryRepo{}
+	idempotency := &mockIdempotencyRepo{existsResult: true}
+
+	h := &Handler{
+		service:         NewInventoryService(repo),
+		producer:        nil, // must not be reached
+		idempotencyRepo: idempotency,
+		config:          &config.Config{},
+	}
+
+	meta := models.RecordMetadata{
+		EventType: models.EventReserveInventory,
+		EventID:   uuid.New(),
+		SagaID:    uuid.New(),
+		OrderID:   uuid.New(),
+	}
+
+	err := h.HandleCommand(context.Background(), &kgo.Record{
+		Headers: []kgo.RecordHeader{makeMetadataHeader(t, meta)},
+		Value:   []byte("{}"),
+	})
+
+	require.NoError(t, err)
+	assert.False(t, repo.reserveCalled, "service must not run for a duplicate command")
+	assert.False(t, idempotency.createCalled, "no key should be stored for a duplicate")
+}
+
+func TestHandleCommand_StoresKeyAfterSuccess(t *testing.T) {
+	repo := &mockInventoryRepo{}
+	idempotency := &mockIdempotencyRepo{existsResult: false}
+
+	h := &Handler{
+		service:         NewInventoryService(repo),
+		producer:        &mockPublisher{},
+		idempotencyRepo: idempotency,
+		config:          &config.Config{},
+	}
+
+	eventID := uuid.New()
+	meta := models.RecordMetadata{
+		EventType: models.EventReserveInventory,
+		EventID:   eventID,
+		SagaID:    uuid.New(),
+		OrderID:   uuid.New(),
+	}
+	cmd := models.ReserveInventoryCommand{Products: validProducts}
+	payload, err := sonic.Marshal(cmd)
+	require.NoError(t, err)
+
+	err = h.HandleCommand(context.Background(), &kgo.Record{
+		Headers: []kgo.RecordHeader{makeMetadataHeader(t, meta)},
+		Value:   payload,
+	})
+
+	require.NoError(t, err)
+	assert.True(t, repo.reserveCalled, "service should run for a new command")
+	assert.True(t, idempotency.createCalled, "key should be stored after success")
+	assert.Equal(t, eventID.String(), idempotency.createdKey)
 }

--- a/internal/inventory/service_test.go
+++ b/internal/inventory/service_test.go
@@ -15,15 +15,19 @@ import (
 
 // mockInventoryRepo is a hand-written mock for InventoryReservationRepository.
 type mockInventoryRepo struct {
-	reserveErr error
-	releaseErr error
+	reserveErr    error
+	releaseErr    error
+	reserveCalled bool
+	releaseCalled bool
 }
 
 func (m *mockInventoryRepo) ReserveItems(_ context.Context, _ uuid.UUID, _ []models.InventoryProduct) error {
+	m.reserveCalled = true
 	return m.reserveErr
 }
 
 func (m *mockInventoryRepo) ReleaseItems(_ context.Context, _ uuid.UUID, _ []models.InventoryProduct) error {
+	m.releaseCalled = true
 	return m.releaseErr
 }
 

--- a/internal/payment/handler.go
+++ b/internal/payment/handler.go
@@ -3,7 +3,9 @@ package payment
 import (
 	"context"
 	"fmt"
+	"log"
 
+	"github.com/bytedance/sonic"
 	"github.com/google/uuid"
 	"github.com/mateusmlo/altimit-ecomm/internal/config"
 	"github.com/mateusmlo/altimit-ecomm/internal/errs"
@@ -14,18 +16,20 @@ import (
 )
 
 type Handler struct {
-	service   *PaymentService
-	producer  *kafka.Producer
-	orderRepo repository.OrderRepository
-	config    *config.Config
+	service         *PaymentService
+	producer        kafka.EventPublisher
+	orderRepo       repository.OrderRepository
+	idempotencyRepo repository.IdempotencyRepository
+	config          *config.Config
 }
 
-func NewHandler(service *PaymentService, producer *kafka.Producer, orderRepo repository.OrderRepository, config *config.Config) *Handler {
+func NewHandler(service *PaymentService, producer kafka.EventPublisher, orderRepo repository.OrderRepository, idempotencyRepo repository.IdempotencyRepository, config *config.Config) *Handler {
 	return &Handler{
-		service:   service,
-		producer:  producer,
-		orderRepo: orderRepo,
-		config:    config,
+		service:         service,
+		producer:        producer,
+		orderRepo:       orderRepo,
+		idempotencyRepo: idempotencyRepo,
+		config:          config,
 	}
 }
 
@@ -33,6 +37,17 @@ func (h *Handler) HandleCommand(ctx context.Context, rec *kgo.Record) error {
 	metadata, err := kafka.ExtractMetadata(rec.Headers)
 	if err != nil {
 		return err
+	}
+
+	key := metadata.EventID.String()
+
+	exists, err := h.idempotencyRepo.Exists(ctx, key)
+	if err != nil {
+		return err
+	}
+	if exists {
+		log.Printf("Duplicate command %s already processed, skipping", key)
+		return nil
 	}
 
 	var reply *models.PaymentReply
@@ -52,7 +67,25 @@ func (h *Handler) HandleCommand(ctx context.Context, rec *kgo.Record) error {
 		return err
 	}
 
-	return h.publishReply(ctx, metadata, reply)
+	if err := h.publishReply(ctx, metadata, reply); err != nil {
+		return err
+	}
+
+	return h.storeIdempotencyKey(ctx, key, reply)
+}
+
+// storeIdempotencyKey records the processed command keyed by EventID so a
+// redelivered command is suppressed. Called after a successful publishReply.
+func (h *Handler) storeIdempotencyKey(ctx context.Context, key string, reply *models.PaymentReply) error {
+	response, err := sonic.Marshal(reply)
+	if err != nil {
+		return err
+	}
+
+	return h.idempotencyRepo.Create(ctx, &models.IdempotencyKey{
+		Key:      key,
+		Response: response,
+	})
 }
 
 func (h *Handler) handleProcessPayment(ctx context.Context, orderID uuid.UUID) (*models.PaymentReply, error) {

--- a/internal/payment/handler_test.go
+++ b/internal/payment/handler_test.go
@@ -1,0 +1,211 @@
+package payment
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
+	"github.com/mateusmlo/altimit-ecomm/internal/config"
+	"github.com/mateusmlo/altimit-ecomm/internal/errs"
+	"github.com/mateusmlo/altimit-ecomm/internal/models"
+	"github.com/mateusmlo/altimit-ecomm/internal/stripe/stripetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// mockIdempotencyRepo is a hand-written mock for IdempotencyRepository.
+type mockIdempotencyRepo struct {
+	existsResult bool
+	existsErr    error
+	createErr    error
+	createdKey   string
+	createCalled bool
+}
+
+func (m *mockIdempotencyRepo) Create(_ context.Context, key *models.IdempotencyKey) error {
+	m.createCalled = true
+	m.createdKey = key.Key
+	return m.createErr
+}
+
+func (m *mockIdempotencyRepo) GetByKey(_ context.Context, _ string) (*models.IdempotencyKey, error) {
+	return nil, nil
+}
+
+func (m *mockIdempotencyRepo) Exists(_ context.Context, _ string) (bool, error) {
+	return m.existsResult, m.existsErr
+}
+
+func (m *mockIdempotencyRepo) Delete(_ context.Context, _ string) error { return nil }
+
+func (m *mockIdempotencyRepo) DeleteOlderThan(_ context.Context, _ time.Duration) error { return nil }
+
+// mockOrderRepo is a hand-written mock for OrderRepository.
+type mockOrderRepo struct {
+	order *models.Order
+	err   error
+}
+
+func (m *mockOrderRepo) Create(_ context.Context, _ *models.Order) error { return nil }
+func (m *mockOrderRepo) GetByID(_ context.Context, _ uuid.UUID) (*models.Order, error) {
+	return m.order, m.err
+}
+func (m *mockOrderRepo) GetByPublicID(_ context.Context, _ string) (*models.Order, error) {
+	return m.order, m.err
+}
+func (m *mockOrderRepo) GetByCustomerID(_ context.Context, _ string, _, _ int) ([]*models.Order, error) {
+	return nil, nil
+}
+func (m *mockOrderRepo) Update(_ context.Context, _ *models.Order) error              { return nil }
+func (m *mockOrderRepo) UpdateStatus(_ context.Context, _ uuid.UUID, _ models.OrderStatus) error {
+	return nil
+}
+func (m *mockOrderRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
+func (m *mockOrderRepo) List(_ context.Context, _, _ int) ([]*models.Order, error) {
+	return nil, nil
+}
+
+// mockPaymentRepo is a hand-written mock for PaymentRepository.
+type mockPaymentRepo struct {
+	createCalled bool
+}
+
+func (m *mockPaymentRepo) Create(_ context.Context, _ *models.Payment) error {
+	m.createCalled = true
+	return nil
+}
+func (m *mockPaymentRepo) GetByID(_ context.Context, _ uuid.UUID) (*models.Payment, error) {
+	return nil, nil
+}
+func (m *mockPaymentRepo) GetByOrderID(_ context.Context, _ uuid.UUID) (*models.Payment, error) {
+	return nil, nil
+}
+func (m *mockPaymentRepo) Update(_ context.Context, _ *models.Payment) error { return nil }
+func (m *mockPaymentRepo) UpdateStatus(_ context.Context, _ uuid.UUID, _ models.PaymentStatus) error {
+	return nil
+}
+func (m *mockPaymentRepo) Delete(_ context.Context, _ uuid.UUID) error { return nil }
+func (m *mockPaymentRepo) List(_ context.Context, _, _ int) ([]*models.Payment, error) {
+	return nil, nil
+}
+func (m *mockPaymentRepo) GetByStatus(_ context.Context, _ models.PaymentStatus, _, _ int) ([]*models.Payment, error) {
+	return nil, nil
+}
+
+// mockPublisher records the last published event for assertions.
+type mockPublisher struct {
+	publishErr error
+	lastTopic  string
+	lastEvent  models.Event
+}
+
+func (m *mockPublisher) PublishEvent(_ context.Context, topic string, ev models.Event) error {
+	m.lastTopic = topic
+	m.lastEvent = ev
+	return m.publishErr
+}
+
+func makeMetadataHeader(t *testing.T, m models.RecordMetadata) kgo.RecordHeader {
+	t.Helper()
+	b, err := sonic.Marshal(m)
+	require.NoError(t, err)
+	return kgo.RecordHeader{Key: "metadata", Value: b}
+}
+
+func TestHandleCommand_MissingMetadataHeader(t *testing.T) {
+	h := &Handler{idempotencyRepo: &mockIdempotencyRepo{}, config: &config.Config{}}
+
+	err := h.HandleCommand(context.Background(), &kgo.Record{
+		Headers: []kgo.RecordHeader{},
+		Value:   []byte("{}"),
+	})
+
+	assert.ErrorIs(t, err, errs.ErrMissingMetadata)
+}
+
+func TestHandleCommand_UnknownEventType(t *testing.T) {
+	h := &Handler{idempotencyRepo: &mockIdempotencyRepo{}, config: &config.Config{}}
+
+	meta := models.RecordMetadata{
+		EventType: models.EventType("UNKNOWN_EVENT"),
+		EventID:   uuid.New(),
+		SagaID:    uuid.New(),
+		OrderID:   uuid.New(),
+	}
+
+	err := h.HandleCommand(context.Background(), &kgo.Record{
+		Headers: []kgo.RecordHeader{makeMetadataHeader(t, meta)},
+		Value:   []byte("{}"),
+	})
+
+	assert.ErrorIs(t, err, errs.ErrUnknownEvent)
+}
+
+func TestHandleCommand_DuplicateSuppressed(t *testing.T) {
+	orderRepo := &mockOrderRepo{}
+	paymentRepo := &mockPaymentRepo{}
+	idempotency := &mockIdempotencyRepo{existsResult: true}
+
+	h := &Handler{
+		service:         NewPaymentService(stripetest.New(), paymentRepo),
+		producer:        nil, // must not be reached
+		orderRepo:       orderRepo,
+		idempotencyRepo: idempotency,
+		config:          &config.Config{},
+	}
+
+	meta := models.RecordMetadata{
+		EventType: models.EventProcessPayment,
+		EventID:   uuid.New(),
+		SagaID:    uuid.New(),
+		OrderID:   uuid.New(),
+	}
+
+	err := h.HandleCommand(context.Background(), &kgo.Record{
+		Headers: []kgo.RecordHeader{makeMetadataHeader(t, meta)},
+		Value:   []byte("{}"),
+	})
+
+	require.NoError(t, err)
+	assert.False(t, paymentRepo.createCalled, "service must not run for a duplicate command")
+	assert.False(t, idempotency.createCalled, "no key should be stored for a duplicate")
+}
+
+func TestHandleCommand_StoresKeyAfterSuccess(t *testing.T) {
+	orderRepo := &mockOrderRepo{order: &models.Order{
+		ID:          uuid.New(),
+		TotalAmount: 42.00,
+		Currency:    "USD",
+	}}
+	paymentRepo := &mockPaymentRepo{}
+	idempotency := &mockIdempotencyRepo{existsResult: false}
+
+	h := &Handler{
+		service:         NewPaymentService(stripetest.New(), paymentRepo),
+		producer:        &mockPublisher{},
+		orderRepo:       orderRepo,
+		idempotencyRepo: idempotency,
+		config:          &config.Config{},
+	}
+
+	eventID := uuid.New()
+	meta := models.RecordMetadata{
+		EventType: models.EventProcessPayment,
+		EventID:   eventID,
+		SagaID:    uuid.New(),
+		OrderID:   uuid.New(),
+	}
+
+	err := h.HandleCommand(context.Background(), &kgo.Record{
+		Headers: []kgo.RecordHeader{makeMetadataHeader(t, meta)},
+		Value:   []byte("{}"),
+	})
+
+	require.NoError(t, err)
+	assert.True(t, paymentRepo.createCalled, "service should run for a new command")
+	assert.True(t, idempotency.createCalled, "key should be stored after success")
+	assert.Equal(t, eventID.String(), idempotency.createdKey)
+}


### PR DESCRIPTION
Closes #16.

## What

Wires the existing (but previously uncalled) `IdempotencyRepository` into the **payment** and **inventory** command handlers, keyed by the Kafka record's `EventID`. Kafka's at-least-once delivery means a redelivered command would otherwise re-run side effects — duplicate Stripe charges, double inventory reservations.

## How

In each handler's `HandleCommand`, after extracting metadata:
1. `Exists(ctx, EventID)` — on a hit, log and return nil **before** dispatching to the service (no duplicate side effect).
2. On a miss, dispatch → `publishReply` → then `Create` the key with the marshaled reply as `Response`.

Storing the key **after** a successful publish means a publish failure leaves no key behind, so the command is safely retried. The handler `producer` field is switched to the existing `kafka.EventPublisher` interface (the pattern the orchestrator already uses) for broker-free unit tests.

### Decisions
- **Duplicate behavior: skip, don't re-publish.** A stored key proves the original reply already published successfully, so a redelivery is only a lost offset-commit — re-publishing would just send the orchestrator a redundant reply for its saga-state machine to absorb. The `Response` is still stored (for audit / a potential future replay path).
- **Orchestrator left unguarded** (per the issue): its new-order path dedups via `sagaRepo.GetByOrderID`, and its reply path routes on the persisted saga `Status` state machine.
- **Known out-of-scope window:** storing the key after the side effect leaves a small re-execution window (side effect succeeds → crash before `Create`). Fully closing it needs the key write atomic with the side effect, or Stripe-native idempotency keys.

## Tests
- New unit tests (`internal/payment/handler_test.go`, extended `internal/inventory/handler_test.go`) with a hand-written `mockIdempotencyRepo`: duplicate is suppressed without invoking the service or storing a key; a new command stores the key under its `EventID` after success.
- The cmd integration tests now construct a real `IdempotencyRepository`, exercising enforcement end-to-end.

All green: `go build/vet ./...`, `go test ./...`, and `-tags=integration` for the repository and all three cmd suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)